### PR TITLE
Update combine_bgc_output.R

### DIFF
--- a/R/combine_bgc_output.R
+++ b/R/combine_bgc_output.R
@@ -31,7 +31,7 @@ combine_bgc_output <- function(results.dir,
   writeLines(paste0("\n\nLoading input files with prefix ", prefix, "...\n"))
   
   lnl <- list.files(path = results.dir,
-                    pattern = paste0(prefix, ".*LnL_\\d+$"),
+                    pattern = paste0(prefix, ".*lnl_\\d+$"),
                     full.names = TRUE)
   check_if_files(lnl)
   


### PR DESCRIPTION
Fixed issue in combine_bgc_output.R in which code was searching for files containing LnL instead of lnl. Fixes issue #29.